### PR TITLE
Adds support for hound styles

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -67,6 +67,7 @@ node default {
 
   # Custom modules
   include platanus::environment
+  include platanus::hound
 
   # common, useful packages
   package {

--- a/modules/platanus/manifests/hound.pp
+++ b/modules/platanus/manifests/hound.pp
@@ -1,0 +1,11 @@
+class platanus::hound (
+  $path = "${boxen::config::srcdir}/hound",
+) {
+
+  # Clone Hound
+  repository { $path:
+    source  => 'platanus/hound',
+    path    => $path
+  }
+
+}

--- a/modules/platanus/manifests/hound/ruby.pp
+++ b/modules/platanus/manifests/hound/ruby.pp
@@ -12,7 +12,7 @@ class platanus::hound::ruby {
 
   ruby_gem { 'rubocop for all rubies':
     gem          => 'rubocop',
-    version      => '~> 0.29.1',
+    version      => '0.34.2',
     ruby_version => '*'
   }
 

--- a/modules/platanus/manifests/hound/ruby.pp
+++ b/modules/platanus/manifests/hound/ruby.pp
@@ -1,0 +1,19 @@
+class platanus::hound::ruby {
+
+  require platanus::hound
+
+  $home = "/Users/${::boxen_user}"
+
+  file { "${home}/.rubocop.yml":
+		ensure => link,
+		target => "${platanus::hound::path}/config/style_guides/platanus/ruby.yml",
+		require => Class[platanus::hound]
+	}
+
+  ruby_gem { 'rubocop for all rubies':
+    gem          => 'rubocop',
+    version      => '~> 0.29.1',
+    ruby_version => '*'
+  }
+
+}

--- a/modules/stacks/manifests/ruby.pp
+++ b/modules/stacks/manifests/ruby.pp
@@ -1,4 +1,5 @@
 class stacks::ruby {
+  include platanus::hound::ruby
 
   # Ruby and gems
   class { 'ruby::global':


### PR DESCRIPTION
- Clones the platanus/hound repo in the src folder
- Adds a symlink for ruby styles `$HOME/.rubocop.yml -> $HOME/src/hound/config/style_guides/ruby.yml`
- Install rubocop in all ruby versions

The idea is to have the rubocop styles availeble in the home directory, that way rubocop should use that styles by default.

You must install the rubocop linter for your favorite text editor ant config the rubocop executable to `/opt/boxen/rbenv/shims/rubocop`